### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ VERSION          = '0.1.4'
 PYTHON_REQUIRES  = ">=3.7"
 
 INSTALL_REQUIRES = [
-    'biopython>=1.78',
+    'biopython==1.78',
     'matplotlib>=3.4.3',
     'patchworklib>=0.4.5',
     'python-queen>=1.1.0',


### PR DESCRIPTION
QUEEN relies on biopython, but biopython has undergone significant changes recently. With biopython=1.83, it will throw an error. Therefore, I have restricted biopython to version 1.78, which allows it to run normally.

biopython -> python-queen -> sangerseq_viewer
```shell
(sangerseq) lhc@GCNSZOA33656E:/mnt/d/1.onworking/sangerseq_viewer$ sangerseq_viewer -s example_data/puc19_spec_2xu6grna.gb -q example_data/ab1/Spec-2xU6gRNA-1.ab1 -o output/example2.png -l 200 --dpi 200
Traceback (most recent call last):
  File "/home/lhc/mambaforge/envs/sangerseq/bin/sangerseq_viewer", line 27, in <module>
    ax_all = view_sanger(gbkpath, abipath, start, end, linebreak=linebreak, output=output, display_quality=quality, dpi=dpi)
  File "/home/lhc/mambaforge/envs/sangerseq/lib/python3.8/site-packages/sangerseq_viewer/sangerseq_viewer.py", line 585, in view_sanger
    template = QUEEN(record=gbkpath)
  File "/home/lhc/mambaforge/envs/sangerseq/lib/python3.8/site-packages/QUEEN/qobj.py", line 672, in __init__
    self._dnafeatures.append(DNAfeature(feature=feat, subject=self))
  File "/home/lhc/mambaforge/envs/sangerseq/lib/python3.8/site-packages/QUEEN/qobj.py", line 125, in __init__
    self._start = self.location.parts[0].start.position
AttributeError: 'ExactPosition' object has no attribute 'position'
```
